### PR TITLE
Rebuild delegated transformer list at the beginning of late phase

### DIFF
--- a/module-gtnhmixins/CREDITS
+++ b/module-gtnhmixins/CREDITS
@@ -9,6 +9,7 @@ Modifications:
 - Added Mixin 0.7 support
 	- Made reflection support Mixin 0.7.11
 - Added call to "unimixins.mixinModidDecorator.refresh" after loading early mixins in GTNHMixinsCore and late mixins in LateMixinOrchestrationMixin
+- Made delegated transformer list get set to null before loading late mixins
 - Added 1.8+ @Mod and @IFMLPlugin annotations
 - Removed MixinExtras
 

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
@@ -78,6 +78,9 @@ public class LateMixinOrchestrationMixin {
             modClassLoader.addFile(container.getSource());
         }
 
+        // Force rebuild of the transformer list
+        Reflection.setDelegatedTransformersField(null);
+
         Field transformerField = Proxy.class.getDeclaredField("transformer");
         transformerField.setAccessible(true);
         


### PR DESCRIPTION
This was brought to my attention in https://github.com/LegacyModdingMC/UniMix/pull/4

Mixin keeps a [list](https://github.com/LegacyModdingMC/UniMix/blob/bbd3c93bd0e1f5979dbeb983cc7f55e73a86e281/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java#L130) of the transformers it should run when loading mixin target classes. The list will [get rebuilt](https://github.com/LegacyModdingMC/UniMix/blob/bbd3c93bd0e1f5979dbeb983cc7f55e73a86e281/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java#L416-L418) if it gets set to null, which [Mixin does at the beginning of each phase](https://github.com/LegacyModdingMC/UniMix/blob/bbd3c93bd0e1f5979dbeb983cc7f55e73a86e281/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java#L349) to make sure it's up to date.

However, GTNHMixins (as well as MixinBooter, MixinBooterLegacy and GasStation) doesn't do this before loading the late mixins, causing transformers added after the DEFAULT phase to not get run by the mixin processor.

This causes an error message when loading late mixins for a class that uses `Optional.Interface`. (Interface stripping is done by `ModAPITransformer`, which gets added after the DEFAULT phase). The mixin still gets applied though, but if `-Dmixin.checks` is enabled, the game will crash.

This PR makes GTNHMixins force a rebuild of the list by setting it to null.

<details>
<summary>Example error</summary>

```
[12:35:54] [Client thread/INFO] [mixin/TConstruct]: Mixing tconstruct.MixinWeapon from mixins.hodgepodge.late.json into tconstruct.library.tools.Weapon
[12:35:54] [Client thread/TRACE] [mixin/TConstruct]: Added class metadata for tconstruct/library/tools/ToolCore to metadata cache
[12:35:54] [Client thread/TRACE] [mixin/TConstruct]: Added class metadata for java/io/PrintStream to metadata cache
[12:35:54] [Client thread/TRACE] [mixin/TConstruct]: Added class metadata for cofh/api/energy/IEnergyContainerItem to metadata cache
[12:35:54] [Client thread/TRACE] [mixin/TConstruct]: Added class metadata for tconstruct/library/modifier/IModifyable to metadata cache
[12:35:54] [Client thread/TRACE] [mixin/TConstruct]: Added class metadata for cofh/core/item/IEqualityOverrideItem to metadata cache
[12:35:54] [Client thread/TRACE] [mixin/TConstruct]: catching
java.lang.ClassNotFoundException: The specified class 'dynamicswordskills.api.ISword' was not found
	at org.spongepowered.asm.service.mojang.MixinServiceLaunchWrapper.getClassBytes(MixinServiceLaunchWrapper.java:533) ~[unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.service.mojang.MixinServiceLaunchWrapper.getClassNode(MixinServiceLaunchWrapper.java:606) ~[unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.ClassInfo.forName(ClassInfo.java:2022) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.ClassInfo.findInHierarchy(ClassInfo.java:1819) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.ClassInfo.findMethodInHierarchy(ClassInfo.java:1675) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.ClassInfo.findMethodInHierarchy(ClassInfo.java:1612) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinTargetContext.validateMethod(MixinTargetContext.java:538) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinTargetContext.transformMethod(MixinTargetContext.java:465) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyNormalMethod(MixinApplicatorStandard.java:535) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyMethods(MixinApplicatorStandard.java:521) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyMixin(MixinApplicatorStandard.java:388) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.apply(MixinApplicatorStandard.java:327) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.TargetClassContext.apply(TargetClassContext.java:421) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.TargetClassContext.applyMixins(TargetClassContext.java:403) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:363) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClass(MixinTransformer.java:234) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClassBytes(MixinTransformer.java:202) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at org.spongepowered.asm.mixin.transformer.Proxy.transform(Proxy.java:72) [unimixins-mixin-1.7.10-0.1.12+unimix.0.12.2-mixin.0.8.5-dev.jar:0.12.2+mixin.0.8.5]
	at net.minecraft.launchwrapper.LaunchClassLoader.runTransformers(LaunchClassLoader.java:279) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:176) [launchwrapper-1.12.jar:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419) [?:1.8.0_362]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352) [?:1.8.0_362]
	at cpw.mods.fml.common.asm.transformers.EventSubscriptionTransformer.buildEvents(EventSubscriptionTransformer.java:90) [recompiled_minecraft-1.7.10.jar:?]
	at cpw.mods.fml.common.asm.transformers.EventSubscriptionTransformer.transform(EventSubscriptionTransformer.java:66) [recompiled_minecraft-1.7.10.jar:?]
	at net.minecraft.launchwrapper.LaunchClassLoader.runTransformers(LaunchClassLoader.java:279) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:176) [launchwrapper-1.12.jar:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419) [?:1.8.0_362]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352) [?:1.8.0_362]
	at cpw.mods.fml.common.asm.transformers.EventSubscriptionTransformer.buildEvents(EventSubscriptionTransformer.java:90) [recompiled_minecraft-1.7.10.jar:?]
	at cpw.mods.fml.common.asm.transformers.EventSubscriptionTransformer.transform(EventSubscriptionTransformer.java:66) [recompiled_minecraft-1.7.10.jar:?]
	at net.minecraft.launchwrapper.LaunchClassLoader.runTransformers(LaunchClassLoader.java:279) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:176) [launchwrapper-1.12.jar:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419) [?:1.8.0_362]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352) [?:1.8.0_362]
	at java.lang.Class.forName0(Native Method) [?:1.8.0_362]
	at java.lang.Class.forName(Class.java:348) [?:1.8.0_362]
	at cpw.mods.fml.common.ProxyInjector.inject(ProxyInjector.java:42) [ProxyInjector.class:?]
	at cpw.mods.fml.common.FMLModContainer.constructMod(FMLModContainer.java:512) [FMLModContainer.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_362]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_362]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_362]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_362]
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74) [guava-17.0.jar:?]
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47) [guava-17.0.jar:?]
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322) [guava-17.0.jar:?]
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304) [guava-17.0.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:275) [guava-17.0.jar:?]
	at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212) [LoadController.class:?]
	at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190) [LoadController.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_362]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_362]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_362]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_362]
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74) [guava-17.0.jar:?]
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47) [guava-17.0.jar:?]
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322) [guava-17.0.jar:?]
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304) [guava-17.0.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:275) [guava-17.0.jar:?]
	at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119) [LoadController.class:?]
	at cpw.mods.fml.common.Loader.loadMods(Loader.java:513) [Loader.class:?]
	at cpw.mods.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:208) [FMLClientHandler.class:?]
	at net.minecraft.client.Minecraft.startGame(Minecraft.java:522) [Minecraft.class:?]
	at net.minecraft.client.Minecraft.run(Minecraft.java:5641) [Minecraft.class:?]
	at net.minecraft.client.main.Main.main(Main.java:164) [Main.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_362]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_362]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_362]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_362]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97) [mclauncher-1.7.10.jar:?]
	at GradleStart.main(GradleStart.java:40) [mclauncher-1.7.10.jar:?]
[12:35:54] [Client thread/WARN] [mixin/TConstruct]: Error loading class: dynamicswordskills/api/ISword (java.lang.ClassNotFoundException: The specified class 'dynamicswordskills.api.ISword' was not found)
```
</details>
