### PR TITLE
Add LiteLoader Compat for LATE Mixins

### DIFF
--- a/module-gtnhmixins/gradle.properties
+++ b/module-gtnhmixins/gradle.properties
@@ -1,1 +1,1 @@
-extraVersion=2.1.15
+extraVersion=2.2.0

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
@@ -23,6 +23,7 @@ import org.spongepowered.asm.mixin.transformer.Config;
 import org.spongepowered.asm.mixin.transformer.Proxy;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -106,15 +107,14 @@ public class LateMixinOrchestrationMixin {
         Set<String> mods = new HashSet<>();
         try {
             Class<?> LiteLoaderTweaker = Class.forName("com.mumfrey.liteloader.launch.LiteLoaderTweaker");
-            Class<?> LoadableModClassPath = Class.forName("com.mumfrey.liteloader.core.api.LoadableModClassPath");
+            Method hasValidMetaData = Class.forName("com.mumfrey.liteloader.interfaces.LoadableMod").getMethod("hasValidMetaData");
             Object instance = FieldUtils.readDeclaredStaticField(LiteLoaderTweaker, "instance", true);
             Object bootstrap = FieldUtils.readDeclaredField(instance, "bootstrap", true);
             Object enumerator = FieldUtils.readDeclaredField(bootstrap, "enumerator", true);
             Map<String, ?> enabledContainers = (Map<String, ?>) FieldUtils.readDeclaredField(enumerator, "enabledContainers", true);
             GTNHMixins.LOGGER.info("LiteLoader present, adding its mods to the list.");
             for(Entry<String, ?> e : enabledContainers.entrySet()) {
-                // Classpath mods include e.g. all libraries (lwjgl, guava, etc.) - we don't want those 
-                if(!LoadableModClassPath.isInstance(e.getValue())) {
+                if((boolean) hasValidMetaData.invoke(e.getValue())) {
                     mods.add(e.getKey());
                 }
             }


### PR DESCRIPTION
When LiteLoader is present, its mods will be added to the modlist. This makes deciding wether to load a particular mixin as easy as with FML mods. Detecting litemods via coremod signatures is not possible since not every litemod contains them.