### PR TITLE
New mixins 0.8.7, mixinextras 0.4.1, and ASM 9.7.1

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,5 @@
 install:
    - ./gradlew setupCIWorkspace
    - ./gradlew publishToMavenLocal
+jdk:
+   - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,3 @@
 install:
    - ./gradlew setupCIWorkspace
    - ./gradlew publishToMavenLocal
-jdk:
-   - openjdk17

--- a/module-compat/src/main/java/io/github/legacymoddingmc/unimixins/compat/CompatCore.java
+++ b/module-compat/src/main/java/io/github/legacymoddingmc/unimixins/compat/CompatCore.java
@@ -95,10 +95,16 @@ public class CompatCore implements IFMLLoadingPlugin {
          * case. We add an extra check here, in a method that gets called right before that log message.</p>
          */
         private static void setFmlLoggerToVerbose() {
-            Logger fmlLog = FMLRelaunchLog.log.getLogger();
-            if (!(fmlLog instanceof org.apache.logging.log4j.core.Logger)) {
+            Logger fmlLog;
+            try {
+                fmlLog = FMLRelaunchLog.log.getLogger();
+                if (!(fmlLog instanceof org.apache.logging.log4j.core.Logger)) {
+                    return;
+                }
+            } catch (NoClassDefFoundError e) {
                 return;
             }
+
             org.apache.logging.log4j.core.Logger fmlCoreLog = (org.apache.logging.log4j.core.Logger)fmlLog;
 
             if(fmlCoreLog.getLevel() != Level.ALL) {

--- a/module-gtnhmixins/build.gradle
+++ b/module-gtnhmixins/build.gradle
@@ -3,7 +3,7 @@ def mixinExtrasVersion = "0.1.1"
 configurations.create("shadowMixinExtras")
 
 dependencies {
-	compileOnly('org.spongepowered:mixin:0.8.5')
+	compileOnly('org.spongepowered:mixin:0.8.7')
 	shadow(project(":module-common")) {
 		transitive = false
 	}

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/core/GTNHMixinsCore.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/core/GTNHMixinsCore.java
@@ -95,7 +95,7 @@ public class GTNHMixinsCore implements IFMLLoadingPlugin {
     public void injectData(Map<String, Object> data) {
         LOGGER.info("Examining core mod list");
         final Object coremodList = data.get("coremodList");
-        
+
         if (coremodList instanceof List) {
             final Set<String> loadedCoremods = getLoadedCoremods((List<?>) coremodList);
 
@@ -107,7 +107,7 @@ public class GTNHMixinsCore implements IFMLLoadingPlugin {
                     if (theMod instanceof IEarlyMixinLoader) {
                         final IEarlyMixinLoader loader = (IEarlyMixinLoader)theMod;
                         final String mixinConfig = loader.getMixinConfig();
-                        final Config config = Config.create(mixinConfig);
+                        final Config config = Config.create(mixinConfig, null);
                         final List<String> mixins = loader.getMixins(loadedCoremods);
                         for(String mixin : mixins) {
                             LOGGER.info("Loading [{}] {}", mixinConfig, mixin);

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
@@ -71,7 +71,7 @@ public class LateMixinOrchestrationMixin {
             final String mixinConfig = lateLoader.getMixinConfig();
             GTNHMixins.LOGGER.info("Adding {} mixin configuration.", mixinConfig);
 
-            final Config config = Config.create(mixinConfig);
+            final Config config = Config.create(mixinConfig, null);
             final List<String> mixins = lateLoader.getMixins(loadedMods);
             for(String mixin : mixins) {
                 GTNHMixins.LOGGER.info("Loading [{}] {}", mixinConfig, mixin);

--- a/module-mixin/gradle.properties
+++ b/module-mixin/gradle.properties
@@ -1,7 +1,7 @@
-fabricMixinVersion=0.15.0+mixin.0.8.7
-unimixMixinVersion=0.15.0+mixin.0.8.7
+fabricMixinVersion=0.15.3+mixin.0.8.7
+unimixMixinVersion=0.15.3+mixin.0.8.7
 spongepoweredMixinVersion=0.8.7
 gtnhMixinVersion=0.8.7-GTNH-2
 gasmixMixinVersion=0.8.7-gasstation_7
 
-asmVersion=9.6
+asmVersion=9.7.1

--- a/module-mixin/gradle.properties
+++ b/module-mixin/gradle.properties
@@ -1,7 +1,7 @@
-fabricMixinVersion=0.13.1+mixin.0.8.5
-unimixMixinVersion=0.13.0+mixin.0.8.5
-spongepoweredMixinVersion=0.8.5
-gtnhMixinVersion=0.8.5-GTNH-2
-gasmixMixinVersion=0.8.5-gasstation_7
+fabricMixinVersion=0.15.0+mixin.0.8.7
+unimixMixinVersion=0.15.0+mixin.0.8.7
+spongepoweredMixinVersion=0.8.7
+gtnhMixinVersion=0.8.7-GTNH-2
+gasmixMixinVersion=0.8.7-gasstation_7
 
 asmVersion=9.6

--- a/module-mixinextras/gradle.properties
+++ b/module-mixinextras/gradle.properties
@@ -1,1 +1,1 @@
-mixinExtrasVersion=0.4.0
+mixinExtrasVersion=0.4.1

--- a/module-mixinextras/gradle.properties
+++ b/module-mixinextras/gradle.properties
@@ -1,1 +1,1 @@
-mixinExtrasVersion=0.3.5
+mixinExtrasVersion=0.4.0


### PR DESCRIPTION
Bumps UniMix to 0.15.3_mixin.0.8.7, Mixin Extras to 0.4.1, and ASM to 9.7.1

Notes:

- [x] - Pending - Tested in Full GTNH nightly pack 

Previously tested by FalsePattern w/ GTMega and reported to be working