### PR TITLE
Improves the Bukkit detection as a core mod.

### DIFF
--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/core/GTNHMixinsCore.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/core/GTNHMixinsCore.java
@@ -37,7 +37,7 @@ public class GTNHMixinsCore implements IFMLLoadingPlugin {
     public static final Map<String, String> MANUALLY_IDENTIFIED_COREMODS = ImmutableMap.<String, String>builder()
         .put("optifine.OptiFineForgeTweaker", "optifine.OptiFineForgeTweaker")
         .put("codechicken.lib.asm.ModularASMTransformer", "codechicken.lib")
-        .put("org.bukkit.World", "Bukkit")
+        .put("org.bukkit.Bukkit", "Bukkit")
         .build();
 
     static {

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/core/GTNHMixinsCore.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/core/GTNHMixinsCore.java
@@ -37,7 +37,7 @@ public class GTNHMixinsCore implements IFMLLoadingPlugin {
     public static final Map<String, String> MANUALLY_IDENTIFIED_COREMODS = ImmutableMap.<String, String>builder()
         .put("optifine.OptiFineForgeTweaker", "optifine.OptiFineForgeTweaker")
         .put("codechicken.lib.asm.ModularASMTransformer", "codechicken.lib")
-        .put("org.bukkit.Bukkit", "Bukkit")
+        .put("org.bukkit.DyeColor", "Bukkit")
         .build();
 
     static {


### PR DESCRIPTION
Instead of using the World class to detect if it's a Bukkit core mod, it's safer to use the DyeColor class. 
Using this class shouldn't break Bukkit itself.

That will fix https://github.com/LegacyModdingMC/UniMixins/issues/33 