### PR TITLE
Added support for OptiFineDevTweaker

### DIFF
--- a/module-mixingasm/src/main/resources/assets/mixingasm/default_config/mixingasm/transformer_inclusion_list_default.txt
+++ b/module-mixingasm/src/main/resources/assets/mixingasm/default_config/mixingasm/transformer_inclusion_list_default.txt
@@ -25,3 +25,4 @@ net.minecraftforge.*
 codechicken.core.asm.*
 codechicken.lib.asm.*
 org.spongepowered.asm.*
+ofdev.*


### PR DESCRIPTION
https://github.com/OpenCubicChunks/OptiFineDevTweaker

I've added `ofdev.*` to the list of trusted transformers in Mixingasm, needed to have both running in dev.