### PR TITLE
Merge mixin classes in config file instead of overwriting it

### DIFF
--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/ILateMixinLoader.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/ILateMixinLoader.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.gtnhmixins;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Set;
 
@@ -11,7 +12,7 @@ import java.util.Set;
  * If you want to add mixins that affect vanilla or forge, use and consult {@link IEarlyMixinLoader}
  * <p>
  * Implement this in any arbitrary class, along with the annotation @{@link LateMixin}.  The annotation will cause the class to be constructed when mixins are 
- * ready to be queued. Return all of the mixin classes (under the mixinConfig's package) that you want to queue and send to Mixin library.
+ * ready to be queued. Return additional mixin classes if you want to dynamically enable or disable them, or an empty list if there is none.
  */
 public interface ILateMixinLoader {
 
@@ -22,7 +23,7 @@ public interface ILateMixinLoader {
 
     /**
      * @param loadedMods Set of loaded modids, for use in discrimination of what mixins load
-     * @return mixin configurations to be queued and sent to Mixin library.
+     * @return additional mixin configurations to be queued and sent to Mixin library.
      */
-    List<String> getMixins(Set<String> loadedMods);
+    @Nonnull List<String> getMixins(Set<String> loadedMods);
 }

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/mixins/LateMixinOrchestrationMixin.java
@@ -25,6 +25,7 @@ import org.spongepowered.asm.mixin.transformer.Proxy;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +36,7 @@ import java.util.Set;
 
 @Mixin(value = LoadController.class, remap = false)
 public class LateMixinOrchestrationMixin {
+    @SuppressWarnings("unchecked")
     @Inject(method = "distributeStateMessage(Lcpw/mods/fml/common/LoaderState;[Ljava/lang/Object;)V", at = @At(value = "HEAD"))
     private void beforeConstructing(LoaderState state, Object[] eventData, CallbackInfo ci) throws Throwable {
         // This state is where Forge adds mod files to ModClassLoader
@@ -69,7 +71,9 @@ public class LateMixinOrchestrationMixin {
             GTNHMixins.LOGGER.info("Adding {} mixin configuration.", mixinConfig);
 
             final Config config = Config.create(mixinConfig, null);
-            final List<String> mixins = lateLoader.getMixins(loadedMods);
+            final List<String> mixins = new ArrayList<>();
+            mixins.addAll(lateLoader.getMixins(loadedMods));
+            mixins.addAll((List<String>) Reflection.mixinClassesField.get(Reflection.configField.get(config)));
             for(String mixin : mixins) {
                 GTNHMixins.LOGGER.info("Loading [{}] {}", mixinConfig, mixin);
             }


### PR DESCRIPTION
Fixed a problem that late mixin plugins are fully ignoring the "mixins" section in the config, while "client" is loaded.
