### PR TITLE
Mark GasStation classes as deprecated

### DIFF
--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/GasStation.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/GasStation.java
@@ -10,5 +10,6 @@ import cpw.mods.fml.common.Mod;
         version = Tags.VERSION,
         name = Tags.MODNAME,
         acceptableRemoteVersions = "*")
+@Deprecated
 public class GasStation {
 }

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/IEarlyMixinLoader.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/IEarlyMixinLoader.java
@@ -3,14 +3,9 @@ package com.falsepattern.gasstation;
 import java.util.List;
 
 /**
- * Early mixins are defined as mixins that affects vanilla or forge classes.
- * Or technically, classes that can be queried via the current state of {@link net.minecraft.launchwrapper.LaunchClassLoader}
- * <p>
- * If you want to add mixins that affect mods, use {@link ILateMixinLoader}
- * <p>
- * Implement this in your {@link cpw.mods.fml.relauncher.IFMLLoadingPlugin}.
- * Return all early mixin configs you want MixinBooter to queue and send to Mixin library.
+ * Use {@link com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader} instead!
  */
+@Deprecated
 public interface IEarlyMixinLoader {
 
     /**

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/ILateMixinLoader.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/ILateMixinLoader.java
@@ -2,17 +2,11 @@ package com.falsepattern.gasstation;
 
 import java.util.List;
 
+
 /**
- * Late mixins are defined as mixins that affects mod classes.
- * Or technically, classes that can be queried via the current state of
- * {@link net.minecraft.launchwrapper.LaunchClassLoader}
- * <p>
- * Majority if not all vanilla and forge classes would have been loaded here.
- * If you want to add mixins that affect vanilla or forge, use and consult {@link IEarlyMixinLoader}
- * <p>
- * Implement this in any arbitrary class. Said class will be constructed when mixins are ready to be queued.
- * Return all late mixin configs you want MixinBooter to queue and send to Mixin library.
+ * Use {@link com.gtnewhorizon.gtnhmixins.ILateMixinLoader} instead!
  */
+@Deprecated
 public interface ILateMixinLoader {
 
     /**

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/MinecraftURLClassPath.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/MinecraftURLClassPath.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.file.Path;
 
+@Deprecated
 public class MinecraftURLClassPath {
     /**
      *  Utility to manipulate the minecraft URL ClassPath

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/Tags.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/Tags.java
@@ -2,6 +2,7 @@ package com.falsepattern.gasstation;
 
 // Use this class for Strings only. Do not import any classes here. It will lead to issues with Mixins if in use!
 
+@Deprecated
 public class Tags {
 
     // GRADLETOKEN_* will be replaced by your configuration values at build time

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/core/GasStationCore.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/core/GasStationCore.java
@@ -22,6 +22,7 @@ import java.util.Map;
 @net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex(Integer.MIN_VALUE + 5)
 @net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.Name(GasStationCore.PLUGIN_NAME)
 @net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions("com.falsepattern.gasstation.core")
+@Deprecated
 public class GasStationCore implements IFMLLoadingPlugin {
     public static final String PLUGIN_NAME = Tags.MODNAME + " Core Plugin";
     public static final Logger LOGGER = LogManager.getLogger(PLUGIN_NAME);

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/mixins/DevMixinPlugin.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/mixins/DevMixinPlugin.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+@Deprecated
 public class DevMixinPlugin implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {

--- a/module-gasstation/src/main/java/com/falsepattern/gasstation/mixins/IModDiscovererMixin.java
+++ b/module-gasstation/src/main/java/com/falsepattern/gasstation/mixins/IModDiscovererMixin.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.discovery.ModCandidate;
 
 import java.util.List;
 
+@Deprecated
 public interface IModDiscovererMixin {
     List<ModCandidate> getCandidates();
 }


### PR DESCRIPTION
Follow-up to #49. Also modified the javadoc of the Early/LateMixin interfaces to point people to the gtnhmixins one instead.