### PR TITLE
Add conditional mod exclusions

### DIFF
--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/builders/MixinBuilder.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/builders/MixinBuilder.java
@@ -70,6 +70,14 @@ public class MixinBuilder extends AbstractBuilder {
     }
 
     /**
+     * Specify mods that will disable this mixin if they are present and the condition is true.
+     */
+    public MixinBuilder addExcludedModIf(@Nonnull ITargetMod mod, boolean condition) {
+        if (condition) return (MixinBuilder) super.addExcludedMod(mod);
+        return this;
+    }
+
+    /**
      * Mixins registered from a {@link com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader} need to set this to
      * {@link com.gtnewhorizon.gtnhmixins.builders.IMixins.Phase#EARLY}.
      * <p>

--- a/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/builders/TransformerBuilder.java
+++ b/module-gtnhmixins/src/main/java/com/gtnewhorizon/gtnhmixins/builders/TransformerBuilder.java
@@ -65,6 +65,14 @@ public class TransformerBuilder extends AbstractBuilder {
         return (TransformerBuilder) super.addExcludedMod(mod);
     }
 
+    /**
+     * Specify mods that will disable this transformer if they are present and the condition is true.
+     */
+    public TransformerBuilder addExcludedModIf(@Nonnull ITargetMod mod, boolean condition) {
+        if (condition) return (TransformerBuilder) super.addExcludedMod(mod);
+        return this;
+    }
+
     protected static <E extends Enum<E> & ITransformers> void loadTransformers(Class<E> transformerEnum, List<String> toLoad, List<String> toNotLoad) {
         List<AbstractBuilder> builders = getEnabledBuildersForPhase(transformerEnum, toNotLoad);
         Set<ITargetMod> loadedTargets = getLoadedTargetedMods(builders, null, Collections.emptySet(), Collections.emptySet());


### PR DESCRIPTION
Syntax sugar for cases where you may only want to exclude a mod if a config is set (or not set).
Current use case: a transformer in Hodgepodge that works with DAPI, but only if a slow RFB plugin is enabled.