### PR TITLE
Bump Gradle to 7.6.6

### DIFF
--- a/buildscript/forge-1.7.gradle
+++ b/buildscript/forge-1.7.gradle
@@ -60,7 +60,7 @@ targetCompatibility = 1.8
 repositories {
 	maven {
 		name = "chickenbones"
-		url = "http://chickenbones.net/maven/"
+		url = "https://chickenbones.net/maven/"
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
IDEA was throwing an error on build:
```
Failed to notify build listener. 
> java.lang.NoClassDefFoundError: org/codehaus/groovy/vmplugin/v8/IndyInterface
```
This fixes it, and I don't know why. I hate Groovy.